### PR TITLE
Fixed Typo in Lab 12 

### DIFF
--- a/labs/week12/Lab12.Rmd
+++ b/labs/week12/Lab12.Rmd
@@ -114,7 +114,7 @@ COPY . /myrdoc
 Here, `/myrdoc` is going to be a hidden, complex file system that will contain the entire image. `COPY . /myrdoc` tells Docker to copy all of the files in the current local directory into this hidden folder. 
 
 ```
-CMD Rscript --vanilla hello-world.R
+CMD Rscript --vanilla /myrdoc/hello-world.R
 ```
 
 We have completed creating the file containing instructions on how to make the Docker image, but we haven't actually created that image. To do so, we run the command: 


### PR DESCRIPTION
Sorry for sending a second Pull Request, but when I was reviewing the material I found a small typo that made the hands on Docker demo fail. It's been fixed. 


> This lab focuses on Docker. We will have a couple live examples, and also provide lots of supplementary material that students can look at to get more information as they will likely need at some point. 

> There is also a brief description of Makefiles, and supplementary reading for Makefiles as well. 